### PR TITLE
Append version numbers

### DIFF
--- a/GeneratePrinters.command
+++ b/GeneratePrinters.command
@@ -13,7 +13,8 @@ do
 
 	full_settings_path="${source_for_printers}/${line}"
 	munki_name=$(/usr/libexec/PlistBuddy -c "print name" "${full_settings_path}")
-	pkginfo_path="${munki_pkginfo_printers_folder}/printer_${munki_name}.plist"
+	munki_version=$(/usr/libexec/PlistBuddy -c "print version" "${full_settings_path}")
+	pkginfo_path="${munki_pkginfo_printers_folder}/printer_${munki_name}-${munki_version}.plist"
 
 	"${root_folder}/printer-pkginfo/printer-pkginfo" --plist "${full_settings_path}" > "${pkginfo_path}"
 


### PR DESCRIPTION
Hey Yoann!  Thanks for this script - it made switching to Graham's printer deployment method much easier. :)

I'm submitting this change back, in case it's useful for you.  I wanted the printer pkginfo files to have a version number appended, just like other pkginfo files.  `PlistBuddy` made that pretty easy.

Mike